### PR TITLE
Fix postgres connection uri

### DIFF
--- a/puppet/verifudge/templates/service.systemd.erb
+++ b/puppet/verifudge/templates/service.systemd.erb
@@ -4,7 +4,7 @@ Description=Control the <%=@module_name%>
 [Service]
 PIDFile=/var/run/<%=@module_name%>/<%=@module_name%>.pid
 WorkingDirectory=/opt/<%=@module_name%>
-Environment='<%=@module_name.upcase%>_GUNICORN_PORT=<%=@port%>' '<%=@module_name.upcase%>_GUNICORN_HOST=<%=@host%>' '<%=@module_name.upcase%>_DATABASE_URI=postgres://<%=@module_name%>'
+Environment='<%=@module_name.upcase%>_GUNICORN_PORT=<%=@port%>' '<%=@module_name.upcase%>_GUNICORN_HOST=<%=@host%>' '<%=@module_name.upcase%>_DATABASE_URI=postgres:///<%=@module_name%>'
 Type=simple
 ExecStart=/bin/bash -c './bin/run.sh'
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
The connection string `postgres://verifudge` looks to host verifudge to
expose a db on port 5432. This new connection string
`postgres:///verifudge` looks to localhost to expose a db named
verifudge on port 5432.

The difference is because the `///` causes the connector to assume
`//localhost/` so our connection string gets expanded to
`postgres://localhost/verifudge`.
